### PR TITLE
Update beyonds_carttotals.php

### DIFF
--- a/beyonds_carttotals.php
+++ b/beyonds_carttotals.php
@@ -43,7 +43,10 @@ class Beyonds_carttotals extends Module
         $currentCartHasNotCarrier = !$this->context->cart->id_carrier;
         $isNotFreeDelivery = $params['presentedCart']['subtotals']['shipping']['amount'] != 0;
 
-        if($currentCartHasNotCarrier && $isNotFreeDelivery){
+        if($isNotFreeDelivery) {
+			// Nothing to change in the default PS behavior. Subtotal has to show a no zero delivery cost.
+		}
+		elseif($currentCartHasNotCarrier){
             $params['presentedCart']['subtotals']['shipping']['value'] = $this->trans('To be determined', [], 'Modules.Beyondscarttotals.Shop');
             $params['presentedCart']['totals']['total']['value'] = $params['presentedCart']['subtotals']['products']['value'];
             $params['presentedCart']['totals']['total']['amount'] = $params['presentedCart']['subtotals']['products']['amount'];


### PR DESCRIPTION
If (1) shipping amount was zero and (2) current Carrier was not yet defined, we expect to show "To be determined". However, that was not the case, as the old if condition was not "true" (and the "To be determined" not showed).